### PR TITLE
New module for simple setting of SoC

### DIFF
--- a/givenergy.py
+++ b/givenergy.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""PALM - PV Active Load Manager - separate class file for GivEnergyObj."""
+
+import settings as stgs
+import requests
+
+class GivEnergyObj:
+    """Class for GivEnergy inverter"""
+
+    def __init__(self):
+        sys_item = {'time': '',
+                    'solar': {'power': 0, 'arrays':
+                                  [{'array': 1, 'voltage': 0, 'current': 0, 'power': 0},
+                                   {'array': 2, 'voltage': 0, 'current': 0, 'power': 0}]},
+                    'grid': {'voltage': 0, 'current': 0, 'power': 0, 'frequency': 0},
+                    'battery': {'percent': 0, 'power': 0, 'temperature': 0},
+                    'inverter': {'temperature': 0, 'power': 0, 'output_voltage': 0, \
+                        'output_frequency': 0, 'eps_power': 0},
+                    'consumption': 0}
+        self.sys_status: List[str] = [sys_item] * 5
+
+        meter_item = {'time': '',
+                      'today': {'solar': 0, 'grid': {'import': 0, 'export': 0},
+                                'battery': {'charge': 0, 'discharge': 0}, 'consumption': 0},
+                      'total': {'solar': 0, 'grid': {'import': 0, 'export': 0},
+                                'battery': {'charge': 0, 'discharge': 0}, 'consumption': 0}}
+        self.meter_status: List[str] = [meter_item] * 5
+
+        self.read_time_mins: int = -100
+        self.line_voltage: float = 0
+        self.grid_power: int = 0
+        self.grid_energy: int = 0
+        self.pv_power: int = 0
+        self.pv_energy: int = 0
+        self.batt_power: int = 0
+        self.consumption: int = 0
+        self.soc: int = 0
+        self.base_load = stgs.GE.base_load
+        self.tgt_soc = 100
+        self.cmd_list = stgs.GE_Command_list['data']
+
+        if DEBUG_MODE:
+            print("Valid inverter commands:")
+            for line in self.cmd_list:
+                print(line['id'], " - ", line['name'])
+            print("")
+
+    def get_latest_data(self):
+        """Download latest data from GivEnergy."""
+
+        utc_timenow_mins = t_to_mins(time.strftime("%H:%M:%S", time.gmtime()))
+        if (utc_timenow_mins > self.read_time_mins + 5 or
+            utc_timenow_mins < self.read_time_mins):  # Update every 5 minutes plus day rollover
+
+            url = stgs.GE.url + "system-data/latest"
+            key = stgs.GE.key
+            headers = {
+                'Authorization': 'Bearer  ' + key,
+                'Content-Type': 'application/json',
+                'Accept': 'application/json'
+            }
+
+            try:
+                resp = requests.request('GET', url, headers=headers)
+            except requests.exceptions.RequestException as error:
+                print(error)
+                return
+
+            if len(resp.content) > 100:
+                for index in range(4, -1, -1):  # Right shift old data
+                    if index > 0:
+                        self.sys_status[index] = self.sys_status[index - 1]
+                    else:
+                        try:
+                            self.sys_status[index] = \
+                                json.loads(resp.content.decode('utf-8'))['data']
+                        except Exception:
+                            print("Error reading GivEnergy system status ", T_NOW_VAR)
+                            print(resp.content)
+                            self.sys_status[index] = self.sys_status[index + 1]
+                if LOOP_COUNTER_VAR == 0:  # Pack array on startup
+                    index = 1
+                    while index < 5:
+                        self.sys_status[index] = self.sys_status[0]
+                        index += 1
+                self.read_time_mins = t_to_mins(self.sys_status[0]['time'][11:])
+                self.line_voltage = float(self.sys_status[0]['grid']['voltage'])
+                self.grid_power = -1 * int(self.sys_status[0]['grid']['power'])  # -ve = export
+                self.pv_power = int(self.sys_status[0]['solar']['power'])
+                self.batt_power = int(self.sys_status[0]['battery']['power'])  # -ve = charging
+                self.consumption = int(self.sys_status[0]['consumption'])
+                self.soc = int(self.sys_status[0]['battery']['percent'])
+
+            url = stgs.GE.url + "meter-data/latest"
+            try:
+                resp = requests.request('GET', url, headers=headers)
+            except requests.exceptions.RequestException as error:
+                print(error)
+                return
+
+            if len(resp.content) > 100:
+                for index in range(4, -1, -1):  # Right shift old data
+                    if index > 0:
+                        self.meter_status[index] = self.meter_status[index - 1]
+                    else:
+                        try:
+                            self.meter_status[index] = \
+                                json.loads(resp.content.decode('utf-8'))['data']
+                        except Exception:
+                            print("Error reading GivEnergy meter status ", T_NOW_VAR)
+                            print(resp.content)
+                            self.meter_status[index] = self.meter_status[index + 1]
+                if LOOP_COUNTER_VAR == 0:  # Pack array on startup
+                    index = 1
+                    while index < 5:
+                        self.meter_status[index] = self.meter_status[0]
+                        index += 1
+
+                self.pv_energy = int(self.meter_status[0]['today']['solar'] * 1000)
+
+                # Daily grid energy must be >=0 for PVOutput.org (battery charge >= midnight value)
+                self.grid_energy = max(int(self.meter_status[0]['today']['consumption'] * 1000), 0)
+
+    def get_load_hist(self):
+        """Download historical consumption data from GivEnergy and pack array for next SoC calc"""
+
+        day_delta = 0 if (T_NOW_MINS_VAR > 1430) else 1  # Use latest full day
+        day = datetime.strftime(datetime.now() - timedelta(day_delta), '%Y-%m-%d')
+        url = stgs.GE.url + "data-points/" + day
+        key = stgs.GE.key
+        headers = {
+            'Authorization': 'Bearer  ' + key,
+            'Content-Type': 'application/json',
+            'Accept': 'application/json'
+        }
+        params = {
+            'page': '1',
+            'pageSize': '2000'
+        }
+
+        try:
+            resp = requests.request('GET', url, headers=headers, params=params)
+        except requests.exceptions.RequestException as error:
+            print(error)
+            return
+
+        if len(resp.content) > 100:
+            history = json.loads(resp.content.decode('utf-8'))
+            index = 0
+            counter = 0
+            current_energy = prev_energy = 0
+            while index < 284:
+                try:
+                    current_energy = float(history['data'][index]['today']['consumption'])
+                except Exception:
+                    break
+                if counter == 0:
+                    self.base_load[counter] = round(current_energy, 1)
+                else:
+                    self.base_load[counter] = round(current_energy - prev_energy, 1)
+                counter += 1
+                prev_energy = current_energy
+                index += 12
+            print("Info; Load Calc Summary:", current_energy, self.base_load)
+
+    def set_mode(self, cmd: str, *arg: str):
+        """Configures inverter operating mode"""
+
+        def set_inverter_register(register: str, value: str):
+            """Exactly as it says"""
+
+            # Removed check as it can throw errors if network down on startup
+            cmd_name = ""
+            for line in self.cmd_list:
+                if line['id'] == int(register):
+                    cmd_name = line['name']
+                    break
+
+            url = stgs.GE.url + "settings/" + register + "/write"
+            key = stgs.GE.key
+            headers = {
+                'Authorization': 'Bearer  ' + key,
+                'Content-Type': 'application/json',
+                'Accept': 'application/json'
+            }
+            payload = {
+                'value': value
+            }
+            resp = ""
+            if not TEST_MODE:
+                try:
+                    resp = requests.request('POST', url, headers=headers, json=payload)
+                except requests.exceptions.RequestException as error:
+                    print(error)
+                    return
+            print("Info; Setting Register ", register, " (", cmd_name, ") to ", value, ", \
+                    Response:", resp, sep='')
+
+        if cmd == "set_soc":  # Sets target SoC to value
+            set_inverter_register("77", arg[0])
+            if stgs.GE.start_time != "":
+                set_inverter_register("64", stgs.GE.start_time)
+            if stgs.GE.end_time != "":
+                set_inverter_register("65", stgs.GE.end_time)
+
+        elif cmd == "set_soc_winter":  # Restore default overnight charge params
+            set_inverter_register("77", "100")
+            if stgs.GE.start_time != "":
+                set_inverter_register("64", stgs.GE.start_time)
+            if stgs.GE.end_time_winter != "":
+                set_inverter_register("65", stgs.GE.end_time_winter)
+
+        elif cmd == "charge_now":
+            set_inverter_register("77", "100")
+            set_inverter_register("64", "00:30")
+            set_inverter_register("65", "23:59")
+
+        elif cmd == "pause":
+            set_inverter_register("72", "0")
+            set_inverter_register("73", "0")
+
+        elif cmd == "resume":
+            set_inverter_register("72", "3000")
+            set_inverter_register("73", "3000")
+
+        else:
+            print("error: unknown inverter command:", cmd)
+
+    def compute_tgt_soc(self, gen_fcast, weight: int, commit: bool):
+        """Compute tomorrow's overnight SoC target"""
+
+        # Winter months = 100%
+        if MNTH_VAR in stgs.GE.winter and commit:  # No need for sums...
+            print("info; winter month, SoC set to 100%")
+            self.set_mode("set_soc_winter")
+            return
+
+        # Solcast provides 3 estimates (P10, P50 and P90). Compute individual weighting
+        # factors for each of the 3 estimates from the weight input parameter, using a
+        # triangular approximation for simplicity
+
+        weight = min(max(weight,10),90)  # Range check
+        wgt_10 = max(0, 50 - weight)
+        if weight > 50:
+            wgt_50 = 90 - weight
+        else:
+            wgt_50 = weight - 10
+        wgt_90 = max(0, weight - 50)
+
+        tgt_soc = 100
+        if gen_fcast.pv_est50_day[0] > 0:  # Quick check for valid generation data
+
+            # The clever bit:
+            # Start with a battery at 100%. For each hour of the coming day, calculate the
+            # battery charge based on forecast generation and historical usage. Capture values for
+            # maximum charge and also the minimum charge value at any time before the maximum.
+
+            batt_max_charge: float = stgs.GE.batt_max_charge
+            batt_charge: float = [0] * 24
+            batt_charge[0] = batt_max_charge
+            max_charge = 0
+            min_charge = batt_max_charge
+
+            print("")
+            print("{:<20} {:>10} {:>10} {:>10}  {:>10} {:>10}".format("Info; SoC Calcs;",
+                "Hour", "Charge", "Cons", "Gen", "SoC"))
+
+            if stgs.GE.end_time != "":
+                end_charge_period = int(stgs.GE.end_time[0:2])
+            else:
+                end_charge_period = 4
+
+            index = 0
+            est_gen = 0
+            while index < 24:
+                if index <= end_charge_period:  # Battery is in AC Charge mode
+                    total_load = 0
+                else:
+                    total_load = ge.base_load[index]
+
+                if index > 0:
+                    # Generation is in GMT, add an hour for BST
+                    est_gen = (gen_fcast.pv_est10_hrly[index - 1] * wgt_10 +
+                        gen_fcast.pv_est50_hrly[index - 1] * wgt_50 +
+                        gen_fcast.pv_est90_hrly[index - 1] * wgt_90) / (wgt_10 + wgt_50 + wgt_90)
+
+                    batt_charge[index] = (batt_charge[index - 1] +
+                        max(-1 * stgs.GE.charge_rate,
+                            min(stgs.GE.charge_rate, est_gen - total_load)))
+                    # Capture min charge on lowest down-slope before charge exceeds 100% append
+                    # max xharge if on an up slope after overnight charge
+                    if (batt_charge[index] <= batt_charge[index - 1] and
+                        max_charge < batt_max_charge):
+                        min_charge = min(min_charge, batt_charge[index])
+                    elif index > end_charge_period:  # Charging after overnight boost
+                        max_charge = max(max_charge, batt_charge[index])
+
+                print("{:<20} {:>10} {:>10} {:>10}  {:>10} {:>10}".format("Info; SoC Calc;",
+                    t_to_hrs(index * 60), round(batt_charge[index], 2), round(total_load, 2),
+                    round(est_gen, 2), int(100 * batt_charge[index] / batt_max_charge)))
+
+                index += 1
+
+            max_charge_pcnt = int(100 * max_charge / batt_max_charge)
+            min_charge_pcnt = int(100 * min_charge / batt_max_charge)
+
+            # low_soc is the minimum SoC target. Provide more buffer capacity in shoulder months
+            if MNTH_VAR in stgs.GE.shoulder:
+                low_soc = stgs.GE.max_soc_target
+            else:
+                low_soc = stgs.GE.min_soc_target
+
+            # The really clever bit is just two lines:
+            # Reduce the target SoC to the greater of:
+            #     The surplus above 100% for max_charge_pcnt
+            #     The spare capacity in the battery before the maximum charge point
+            #     The preset minimum value
+            # Range check the resulting value
+            tgt_soc = max(200 - max_charge_pcnt, 100 - min_charge_pcnt, low_soc)
+            tgt_soc = int(min(tgt_soc, 100))  # Limit range to 100%
+
+            print()
+            print("{:<25} {:>10} {:>10} {:>10} {:>10} {:>10}".format("Info; SoC Calc Summary;",
+                "Max Charge", "Min Charge", "Max %", "Min %", "Target SoC"))
+            print("{:<25} {:>10} {:>10} {:>10} {:>10} {:>10}".format("Info; SoC Calc Summary;",
+                round(max_charge, 2), round(min_charge, 2),
+                max_charge_pcnt, min_charge_pcnt, tgt_soc))
+            print("{:<25} {:>10} {:>10} {:>10} {:>10} {:>10}".format("Info; SoC (Adjusted);",
+                round(max_charge, 2), round(min_charge, 2),
+                max_charge_pcnt - 100 + tgt_soc, min_charge_pcnt - 100 + tgt_soc, "\n"))
+
+        else:
+            print("Info; Incomplete Solcast data, setting target SoC to 100%")
+
+        print("Info; SoC Summary; ", LONG_T_NOW_VAR, "; Tom Fcast Gen (kWh); ",
+            gen_fcast.pv_est10_day[0], ";", gen_fcast.pv_est50_day[0], ";",
+            gen_fcast.pv_est90_day[0], "; SoC Target (%); ", tgt_soc,
+            "; Today Gen (kWh); ", round(self.pv_energy) / 1000, 2)
+
+        if commit:
+            self.set_mode("set_soc", str(tgt_soc))
+            self.tgt_soc = tgt_soc
+
+# End of GivEnergyObj() class definitionabs
+
+DEBUG_MODE: bool = False
+TEST_MODE: bool = False
+

--- a/palm_soc_simple.py
+++ b/palm_soc_simple.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""PALM - PV Active Load Manager."""
+
+import sys
+import json
+import datetime
+from typing import Tuple, List
+import requests
+import settings as stgs
+import random
+from urllib.request import urlopen
+from givenergy import GivEnergyObj
+	
+# Copyright 2023, Steve Lewis. All rights reserved. (see palm.py for full comments and license info)
+# NOTE: Simplified version of palm_soc by Graham Hobson created 27 May 2023 designed to be run once a day to
+# set max battery recharge level based on a simple forecast of solar generation tomorrow. Simplifications are:
+# no load calcs, no consideration of month of the year, simplified solcast retrieval, only use estimate_50
+# values. Two new values in settings.py: good_generation_day_kwh and bad_generation_day_kwh
+
+PALM_VERSION = "v0.8.6SoC-Simple1.0"
+# -*- coding: utf-8 -*-
+
+def get_solcast_forecast():
+    forecast = 0.0
+
+    # get full URL to call solcast with API key
+    solcast_url = stgs.Solcast.url_se + stgs.Solcast.cmd + "&api_key=" + stgs.Solcast.key
+    
+    # check if we are running this before 2am, if so get forecast for today's date, but otherwise get tomorrow
+    if datetime.datetime.now().hour < 2:
+        offset = 0    # use today's date
+    else:
+        offset = 1    # use tomorrow's date
+    # get the target date in YYYY-MM-DD format (to compare with the json period_end data)
+    forecast_date = (datetime.date.today() + datetime.timedelta(days=offset)).strftime('%Y-%m-%d')
+    
+    jsondata = json.loads(urlopen(solcast_url).read())
+    for rec in jsondata['forecasts']:
+        this_estimate = rec['pv_estimate']/2 # divide estimate by 2 top get kWh because these are 30 minute time periods
+        this_period = rec['period_end']
+        if this_period[0:10] == forecast_date:
+            forecast += this_estimate
+    return forecast
+# End of get_solcast_forecast() function definition
+
+def mylogger(logtext):
+    
+    with open("palm_soc_simple_log.log", "a") as file1:
+        timestringnow = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        file1.write(timestringnow + " " + logtext)
+        print(timestringnow + " " + logtext)
+        file1.write("\n")
+        file1.close()
+# End of mylogger() function definition
+
+# --------------------------------------------------------------------------------------
+# Start of main
+# --------------------------------------------------------------------------------------
+if __name__ == '__main__':
+
+    pv_forecast = 0.0
+    target_soc: int = 100
+    
+    mylogger("palm_soc_simple.py: PV Automated Load Manager " + PALM_VERSION)
+    print("Runs the forecast collection and inverter update immediately with simple calculation")
+    print("Command line options (only one can be used):")
+    print("    -t | --test  | test mode... no Solcast calls, no GE writes")
+    print("    -d | --debug | debug mode, extra verbose")
+
+    # Parse any command-line arguments
+    TEST_MODE: bool = False
+    DEBUG_MODE: bool = False
+    
+    if len(sys.argv) > 1:
+        if str(sys.argv[1]) in ["-t", "--test"]:
+            TEST_MODE = True
+            DEBUG_MODE = True
+            mylogger("Info: Running in test mode... no Solcast calls, no GE writes")
+        elif str(sys.argv[1]) in ["-d", "--debug"]:
+            DEBUG_MODE = True
+            mylogger("Info: Running in debug mode, extra verbose")
+
+    # GivEnergy power object initialisation
+    ge: GivEnergyObj = GivEnergyObj()
+
+    # use new settings values to get expected generation on a good day, set this to a default if zero
+    if stgs.Solcast.good_generation_day_kwh == 0:     # check if this is not set in settings.py 
+        stgs.Solcast.good_generation_day_kwh = 30
+        
+    mylogger("Good/bad generation days: " + str(stgs.Solcast.good_generation_day_kwh) + "/" + str(stgs.Solcast.bad_generation_day_kwh) + "kWh, min_soc_target: " + str(stgs.GE.min_soc_target) +"%")
+
+    if TEST_MODE: # use a random value for tomorrow's solar generation
+        pv_forecast = random.randrange(0, int(stgs.Solcast.good_generation_day_kwh * 1.3)) # represents kWh tomorrow
+    else: # get the actual solar forecast in kWh
+        pv_forecast = get_solcast_forecast()
+
+    # Calculate max overnight charge based on expectation of solar recharge tomorrow
+    # Use a bit of maths to set inverse relationship between target_soc and pv_forecast
+    # if pv_forecast is at or above good_generation_day_kwh then the battery level will be set to min_soc_target
+    # At the other end of the scale if pv_forecast is low/zero then target_soc will be 100%, sliding scale in between
+    if pv_forecast >= stgs.Solcast.good_generation_day_kwh:
+        target_soc = stgs.GE.min_soc_target
+    elif pv_forecast <= stgs.Solcast.bad_generation_day_kwh:
+        target_soc = 100
+    else:
+        charge_range = 100 - stgs.GE.min_soc_target
+        generation_range = stgs.Solcast.good_generation_day_kwh - stgs.Solcast.bad_generation_day_kwh
+        charge_reduction_factor = (pv_forecast - stgs.Solcast.bad_generation_day_kwh ) / generation_range
+        target_soc = int(stgs.GE.min_soc_target + charge_range - (charge_reduction_factor * charge_range))
+                
+    mylogger("Tom Fcast Gen: " + str(pv_forecast) + "kWh, SoC Target: " + str(target_soc) +"%")
+
+    if not TEST_MODE:
+        # Write final SoC target to GivEnergy register
+        ge.set_mode("set_soc", str(target_soc))
+        mylogger("calling set_mode(set_soc) to set register 77")
+
+    mylogger("------ end ------\n")
+# End of main


### PR DESCRIPTION
Simplified version of palm_soc designed to be run once a day by a scheduler to set max battery recharge level based on a simple forecast of solar generation tomorrow. Simplifications are: no load calcs, no consideration of month of the year, simplified solcast retrieval, only use estimate_50 values. Two new values in settings.py: good_generation_day_kwh and bad_generation_day_kwh
This version also logs key activity to a log file. 
It also separates out the latest GivEnergyObj class into a separate py file. Note that the complex compute_tgt_soc function is not used.